### PR TITLE
Add GitHub Action to check Vite build on pull requests.

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -2,10 +2,12 @@ name: Check Vite Build
 
 on:
   pull_request:
+    types: [opened, synchronize, ready_for_review]
     branches: [main]
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,22 @@
+name: Check Vite Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22' # https://github.com/actions/node-versions/releases
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to verify that the project builds successfully before merging into `main`.

### What it does:
- Runs `npm ci` to install dependencies.
- Executes `npm run build` to ensure the Vite build process completes without errors.
- Triggers only on pull requests targeting `main`.

### Why this is useful:
- Catches build errors early in the review process.
- Prevents broken deployments caused by post-merge build failures.
- Improves CI confidence and developer workflow.

Closes #32 
