### PR TITLE
 Add WebGPU support warning for unsupported browsers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { darkTheme } from 'naive-ui'
-import { onMounted, ref } from 'vue'
+import { ref } from 'vue'
 const code = ref(`// Write your WGSL code here`)
 
 import { loader } from '@guolao/vue-monaco-editor'
@@ -12,15 +12,8 @@ import EditorPanel from './components/EditorPanel.vue'
 import { useTextures } from './composables/useTextures'
 import { useMesh } from './composables/useMesh'
 import ResourcesPanel from './components/ResourcesPanel.vue'
+import WebGPUWarning from './components/WebGPUWarning.vue'
 import './styles/app.css'
-
-const webgpuSupported = ref(true)
-
-onMounted(() => {
-  if (!navigator.gpu) {
-    webgpuSupported.value = false
-  }
-})
 
 const {
   selectedTextures,
@@ -75,15 +68,7 @@ function handleRunShader() {
 </script>
 
 <template>
-  <n-alert
-    v-if="!webgpuSupported"
-    type="warning"
-    title="WebGPU Not Supported"
-    style="margin: 12px;"
-  >
-    Your browser does not support WebGPU. Please use a recent version of Chrome, Edge, or Firefox with WebGPU enabled.
-  </n-alert>
-
+  <WebGPUWarning />
   <n-config-provider :theme="darkTheme">
     <div class="root-grid">
       <n-layout-header bordered style="padding: 12px;">

--- a/src/components/WebGPUWarning.vue
+++ b/src/components/WebGPUWarning.vue
@@ -1,0 +1,22 @@
+<template>
+  <n-alert
+    v-if="!webgpuSupported"
+    type="warning"
+    title="WebGPU Not Supported"
+    style="margin: 12px;"
+  >
+    Your browser does not support WebGPU. Please use a recent version of Chrome, Edge, or Firefox with WebGPU enabled.
+  </n-alert>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const webgpuSupported = ref(true)
+
+onMounted(() => {
+  if (!navigator.gpu) {
+    webgpuSupported.value = false
+  }
+})
+</script>


### PR DESCRIPTION
This PR adds a user-facing warning banner when the browser does not support WebGPU.

### Changes

- Added a conditional check for `navigator.gpu` in the UI.
- Displayed a warning message at the top of the interface if WebGPU is not supported.
- Refactored the banner into a new component (`WebGPUWarning.vue`) for cleaner separation of concerns and reusability.

<img width="1512" height="945" alt="Screenshot 2025-07-21 at 3 23 28 PM" src="https://github.com/user-attachments/assets/aa5ceddf-1e77-4bf3-8043-ed05988fbac8" />

Closes #28 
