### PR TITLE
Fix stale render behavior by cancelling previous animation frame loop

### DIFF
--- a/src/webgpu/renderer.ts
+++ b/src/webgpu/renderer.ts
@@ -5,6 +5,16 @@ import { fullscreenVertexWGSL, injectedHeader, compileShaderModule } from './sha
 import { createUniforms } from './uniforms';
 import { createPipeline } from './pipeline';
 
+let currentFrameId: number | null = null;
+
+// Cancel any active render loop
+export function cancelCurrentRenderLoop() {
+  if (currentFrameId !== null) {
+    cancelAnimationFrame(currentFrameId);
+    currentFrameId = null;
+  }
+}
+
 function runRenderPass(
   device: GPUDevice,
   context: GPUCanvasContext,
@@ -62,6 +72,7 @@ export async function initWebGPU(
   };
 
   console.log("Initializing WebGPU...");
+  cancelCurrentRenderLoop(); // stop any previous render loop
 
   try {
     const { device, adapter } = await getWebGPUDevice();
@@ -180,9 +191,9 @@ export async function initWebGPU(
       device.queue.writeBuffer(mouseBuffer, 0, mouseVec4);
 
       runRenderPass(device, context, pipeline, bindGroup, timeBuffer, startTime, vertexBuffer, vertexData);
-      requestAnimationFrame(frame);
+      currentFrameId = requestAnimationFrame(frame);
     }
-    requestAnimationFrame(frame);
+    currentFrameId = requestAnimationFrame(frame);
 
     // Pop error scope
     const error = await device.popErrorScope();


### PR DESCRIPTION
This PR fixes an issue where invalid WGSL shader code would still display the previous successful render output. The root cause was that the previous `requestAnimationFrame` loop continued running even after a shader compilation failure.

### Changes:
- Introduced `currentFrameId` to track the active render loop
- Added `cancelCurrentRenderLoop()` to stop any previous loop before initializing a new one
- Ensured stale renders are properly canceled on each new run

Closes #18 