### PR TITLE
Remove auto-focus highlight on first preset mesh button in modal

### DIFF
--- a/src/components/MeshModal.vue
+++ b/src/components/MeshModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, watch } from 'vue'
 import { NModal, NCard, NSpace, NButton, NIcon, NUpload } from 'naive-ui'
 import { DownloadOutline } from '@vicons/ionicons5'
 
@@ -19,6 +19,24 @@ const showProxy = computed({
   get: () => props.show,
   set: (val) => emit('update:show', val),
 })
+
+// Prevent misleading focus highlight on first preset button when modal opens
+// Browsers auto-focus the first focusable element (the first .obj button), which Naive UI styles with a green outline
+// This watch removes focus from that element after the modal is mounted to avoid visual confusion
+watch(
+  () => props.show,
+  (newVal) => {
+    if (newVal) {
+      nextTick(() => {
+        // Remove focus from the first auto-focused button
+        const focused = document.activeElement as HTMLElement
+        if (focused && focused.tagName === 'BUTTON') {
+          focused.blur()
+        }
+      })
+    }
+  }
+)
 </script>
 
 <template>


### PR DESCRIPTION
This PR prevents the first preset mesh button in the `MeshModal` from appearing visually highlighted (green) when the modal opens. Modern browsers automatically focus the first focusable element in a modal for accessibility, which in this case is the first `<n-button>`. Naive UI applies a green `:focus-visible` style, which looks like a hover state and may mislead users.

To resolve this, a `watch` on the `show` prop calls `blur()` on the auto-focused button after the modal is mounted, removing the unintended visual focus style.

Before:
<img width="1512" height="945" alt="Screenshot 2025-07-22 at 10 46 26 AM" src="https://github.com/user-attachments/assets/3e9f3b1d-52a7-4e67-bf8a-d744caac9ea2" />

After:
<img width="1512" height="945" alt="Screenshot 2025-07-22 at 10 45 53 AM" src="https://github.com/user-attachments/assets/988f5b65-275b-4b01-aa61-2dcc3e405c2c" />

