### PR TITLE
Update texture format and sampler wrap mode + update corresponding tests

### DIFF
--- a/src/webgpu/textures.ts
+++ b/src/webgpu/textures.ts
@@ -46,7 +46,7 @@ export async function loadDefaultTexture(device: GPUDevice, src: string): Promis
   // Allocates a GPU texture on the device
   const texture = device.createTexture({
     size: [bitmap.width, bitmap.height, 1], // size defines the width, height, and depth (depth = 1 for 2D)
-    format: 'rgba8unorm', // how pixel data is stored — rgba8unorm is a common 8-bit format
+    format: 'rgba8unorm-srgb', // how pixel data is stored — rgba8unorm is a common 8-bit format
     /*
         TEXTURE_BINDING: You want to sample this texture in a shader
         COPY_DST: You're going to copy image data into this texture
@@ -66,6 +66,8 @@ export async function loadDefaultTexture(device: GPUDevice, src: string): Promis
   const sampler = device.createSampler({
     magFilter: 'linear', // smooth interpolation between texels
     minFilter: 'linear',
+    addressModeU: 'repeat',
+    addressModeV: 'repeat',
   });
 
   return {

--- a/tests/backend/textures.test.ts
+++ b/tests/backend/textures.test.ts
@@ -65,8 +65,8 @@ describe('loadDefaultTexture', () => {
     expect(mockDevice.createTexture).toHaveBeenCalledWith(
       expect.objectContaining({
         size: [256, 256, 1],
-        format: 'rgba8unorm',
-        usage: expect.any(Number),
+        format: 'rgba8unorm-srgb',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
       })
     );
 
@@ -81,6 +81,8 @@ describe('loadDefaultTexture', () => {
     expect(mockDevice.createSampler).toHaveBeenCalledWith({
       magFilter: 'linear',
       minFilter: 'linear',
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
     });
 
     expect(result).toEqual({


### PR DESCRIPTION
- Changed texture format from `rgba8unorm` to `rgba8unorm-srgb` for correct gamma handling.
- Updated sampler to use `repeat` for both `addressModeU` and `addressModeV` to enable tiling.
- Update corresponding tests.
