### PR TITLE
Console UI Enhancements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,6 +44,7 @@ loader.config({
 })
 
 const previewRef = ref<InstanceType<typeof PreviewPanel> | null>(null)
+const editorRef = ref<InstanceType<typeof EditorPanel> | null>(null)
 const consoleOutput = ref("")
 
 const { runShader } = useShaderRunner()
@@ -65,6 +66,13 @@ function handleRunShader() {
       consoleOutput.value += (msg || 'Compiled successfully') + '\n'
     }
   })
+}
+
+function handleGoToLine(line: number) {
+  console.log(`App.vue: navigating to line ${line}`);
+  if (editorRef.value) {
+    editorRef.value.goToLine(line)
+  }
 }
 </script>
 
@@ -107,7 +115,12 @@ function handleRunShader() {
 
       <div class="grid-container">
         <!-- Editor (top-left) -->
-        <EditorPanel v-model:code="code" :runShader="handleRunShader" />
+        <EditorPanel
+          ref="editorRef"
+          v-model:code="code"
+          :runShader="handleRunShader"
+          @go-to-line="handleGoToLine"
+        />
 
         <!-- Preview (top-right) -->
          <PreviewPanel ref="previewRef" style="grid-row: 1; grid-column: 2;" />
@@ -136,6 +149,7 @@ function handleRunShader() {
         <!-- Console (bottom-right) -->
         <ConsolePanel
           :console-output="consoleOutput"
+          @go-to-line="handleGoToLine"
           style="grid-row: 2; grid-column: 2;"
         />
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -68,10 +68,10 @@ function handleRunShader() {
   })
 }
 
-function handleGoToLine(line: number) {
-  console.log(`App.vue: navigating to line ${line}`);
+function handleGoToLine(line: number, column?: number) {
+  console.log(`App.vue: navigating to line ${line}${column ? `, column ${column}` : ''}`);
   if (editorRef.value) {
-    editorRef.value.goToLine(line)
+    editorRef.value.goToLine(line, column)
   }
 }
 </script>

--- a/src/components/ConsolePanel.vue
+++ b/src/components/ConsolePanel.vue
@@ -5,14 +5,10 @@
       <!-- Structured error display -->
       <div v-if="structuredErrors.length > 0" class="structured-errors">
         <div v-for="(error, index) in structuredErrors" :key="index"
-             class="error-item"
-             :class="error.severity">
+             class="error-item">
           <div class="error-header">
-            <n-tag
-              :type="error.severity === 'error' ? 'error' : error.severity === 'warning' ? 'warning' : 'info'"
-              size="small"
-            >
-              {{ error.severity.toUpperCase() }}
+            <n-tag type="error" size="small">
+              ERROR
             </n-tag>
             <button
               class="line-link"
@@ -50,7 +46,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { getHeaderLineOffset, parseWebGPUErrors, type ParsedError } from '../webgpu/parser';
+import { getHeaderLineOffset, parseWebGPUErrors } from '../webgpu/parser';
 
 const props = defineProps<{
   consoleOutput: string
@@ -198,21 +194,8 @@ const tokens = computed(() => {
   padding: 12px;
   border-radius: 6px;
   border-left: 4px solid;
-}
-
-.structured-errors .error-item.error {
   background-color: rgba(255, 99, 99, 0.15);
   border-left-color: #ff6363;
-}
-
-.structured-errors .error-item.warning {
-  background-color: rgba(255, 193, 7, 0.15);
-  border-left-color: #ffc107;
-}
-
-.structured-errors .error-item.info {
-  background-color: rgba(23, 162, 184, 0.15);
-  border-left-color: #17a2b8;
 }
 
 .error-item .line-link {

--- a/src/components/ConsolePanel.vue
+++ b/src/components/ConsolePanel.vue
@@ -124,9 +124,6 @@ const tokens = computed(() => {
     let adjustedLine = originalLine;
     if (isCompilationError && !isSyntaxError) {
       adjustedLine = Math.max(1, originalLine - headerOffset);
-      console.log(`Adjusted compilation error line: ${originalLine} -> ${adjustedLine}`);
-    } else {
-      console.log(`Keeping syntax error line unchanged: ${originalLine}`);
     }
 
     out.push({ kind: 'line', num: adjustedLine });

--- a/src/components/ConsolePanel.vue
+++ b/src/components/ConsolePanel.vue
@@ -2,15 +2,98 @@
   <!-- Console (bottom-right) -->
   <n-card title="Console" size="small" class="panel panel-console" style="grid-row: 2; grid-column: 2;">
     <div class="console-content">
-      <pre class="console-pre">{{ consoleOutput }}</pre>
+      <div class="console-pre">
+        <template v-for="(t, i) in tokens" :key="i">
+          <!-- Line link -->
+          <button
+            v-if="t.kind === 'line'"
+            class="line-link"
+            type="button"
+            @click="emit('go-to-line', t.num)"
+            :title="`Jump to line ${t.num}`"
+          >
+            L{{ t.num }}
+          </button>
+          <!-- Plain text -->
+          <span v-else>{{ t.text }}</span>
+        </template>
+      </div>
     </div>
   </n-card>
 </template>
 
 <script setup lang="ts">
-defineProps<{
+import { computed } from 'vue';
+import { getHeaderLineOffset } from '../webgpu/parser';
+
+const props = defineProps<{
   consoleOutput: string
 }>()
+
+const emit = defineEmits<{
+  (e: 'go-to-line', line: number): void
+}>()
+
+// Parse console output for line references - keep it simple
+const tokens = computed(() => {
+  const out: Array<{ kind: 'text'; text: string } | { kind: 'line'; num: number }> = [];
+
+  if (!props.consoleOutput) return out;
+
+  // Get the header offset for adjusting compilation error line numbers
+  const headerOffset = getHeaderLineOffset();
+
+  // Simple approach: just parse the console output for line number links
+  // Don't try to enhance error messages here
+  const re = /\b(?:Line\s*[:#]?\s*(\d+)|L(\d+))\b/gi;
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+
+  while ((m = re.exec(props.consoleOutput)) !== null) {
+    if (m.index > lastIndex) {
+      out.push({ kind: 'text', text: props.consoleOutput.slice(lastIndex, m.index) });
+    }
+
+    const originalLine = Number(m[1] ?? m[2]);
+
+    // TODO: revisit
+    // Determine if this is a compilation error that needs line adjustment
+    // Look for WebGPU compilation error patterns vs Monaco syntax errors
+    const contextStart = Math.max(0, m.index - 100);
+    const contextEnd = Math.min(props.consoleOutput.length, m.index + 100);
+    const context = props.consoleOutput.slice(contextStart, contextEnd);
+
+    // Compilation errors from WebGPU typically contain these patterns
+    const isCompilationError = context.includes('compilation') ||
+                              context.includes('shader failed') ||
+                              context.includes('Invalid') ||
+                              context.includes('error:') ||
+                              (originalLine > headerOffset); // If line number is beyond header, likely compilation error
+
+    // Syntax errors from Monaco typically appear as "Syntax error at line X" with lower line numbers
+    const isSyntaxError = context.includes('Syntax error') ||
+                         context.includes('Expected') ||
+                         (originalLine <= headerOffset && !isCompilationError);
+
+    // Adjust line number for compilation errors only
+    let adjustedLine = originalLine;
+    if (isCompilationError && !isSyntaxError) {
+      adjustedLine = Math.max(1, originalLine - headerOffset);
+      console.log(`Adjusted compilation error line: ${originalLine} -> ${adjustedLine}`);
+    } else {
+      console.log(`Keeping syntax error line unchanged: ${originalLine}`);
+    }
+
+    out.push({ kind: 'line', num: adjustedLine });
+    lastIndex = re.lastIndex;
+  }
+
+  if (lastIndex < props.consoleOutput.length) {
+    out.push({ kind: 'text', text: props.consoleOutput.slice(lastIndex) });
+  }
+
+  return out;
+});
 </script>
 
 <style scoped>
@@ -41,5 +124,66 @@ defineProps<{
   word-break: break-word;       /* avoid horizontal scroll on long tokens */
   font-variant-ligatures: none; /* no confusing 'fi'/'fl' ligatures etc. */
   tab-size: 2;
+}
+
+.line-link {
+  background: none;
+  border: 0;
+  padding: 0 2px;
+  cursor: pointer;
+  text-decoration: underline;
+  color: #4080ff;
+}
+
+.line-link:hover {
+  background-color: rgba(64, 128, 255, 0.1);
+}
+
+/* Error styling */
+.error-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 4px 0;
+  padding: 8px;
+  border-radius: 4px;
+  border-left: 3px solid;
+}
+
+.error-item.error {
+  background-color: rgba(255, 99, 99, 0.1);
+  border-left-color: #ff6363;
+}
+
+.error-item.warning {
+  background-color: rgba(255, 193, 7, 0.1);
+  border-left-color: #ffc107;
+}
+
+.error-item.info {
+  background-color: rgba(23, 162, 184, 0.1);
+  border-left-color: #17a2b8;
+}
+
+.error-icon {
+  flex-shrink: 0;
+  font-size: 14px;
+}
+
+.error-message {
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.error-item .line-link {
+  flex-shrink: 0;
+  font-weight: 500;
+  color: inherit;
+  opacity: 0.8;
+}
+
+.error-item .line-link:hover {
+  opacity: 1;
 }
 </style>

--- a/src/components/ConsolePanel.vue
+++ b/src/components/ConsolePanel.vue
@@ -2,7 +2,7 @@
   <!-- Console (bottom-right) -->
   <n-card title="Console" size="small" class="panel panel-console" style="grid-row: 2; grid-column: 2;">
     <div class="console-content">
-      {{ consoleOutput }}
+      <pre class="console-pre">{{ consoleOutput }}</pre>
     </div>
   </n-card>
 </template>
@@ -31,5 +31,15 @@ defineProps<{
   flex: 1;
   overflow-y: auto;     /* scroll when it overflows */
   padding-bottom: 16px;
+}
+
+.console-pre {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+               "Liberation Mono", "Courier New", monospace;
+  white-space: pre-wrap;        /* keep newlines/indentation, allow wrapping */
+  word-break: break-word;       /* avoid horizontal scroll on long tokens */
+  font-variant-ligatures: none; /* no confusing 'fi'/'fl' ligatures etc. */
+  tab-size: 2;
 }
 </style>

--- a/src/components/ConsolePanel.vue
+++ b/src/components/ConsolePanel.vue
@@ -13,8 +13,8 @@
             <button
               class="line-link"
               type="button"
-              @click="emit('go-to-line', error.line)"
-              :title="`Jump to line ${error.line}`"
+              @click="emit('go-to-line', error.line, error.column)"
+              :title="`Jump to line ${error.line}${error.column ? `, column ${error.column}` : ''}`"
             >
               Line {{ error.line }}{{ error.column ? `:${error.column}` : '' }}
             </button>
@@ -31,7 +31,7 @@
             v-if="t.kind === 'line'"
             class="line-link"
             type="button"
-            @click="emit('go-to-line', t.num)"
+            @click="emit('go-to-line', t.num, undefined)"
             :title="`Jump to line ${t.num}`"
           >
             L{{ t.num }}
@@ -53,7 +53,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'go-to-line', line: number): void
+  (e: 'go-to-line', line: number, column?: number): void
 }>()
 
 // Parse console output into structured errors when possible

--- a/src/components/EditorPanel.vue
+++ b/src/components/EditorPanel.vue
@@ -64,11 +64,11 @@ function onEditorMount(editor: monaco.editor.IStandaloneCodeEditor) {
   editorInstance = editor
 }
 
-// Method to programmatically go to a specific line
-function goToLine(lineNumber: number) {
+// Method to programmatically go to a specific line and optionally column
+function goToLine(lineNumber: number, column?: number) {
   if (editorInstance) {
     editorInstance.revealLineInCenter(lineNumber)
-    editorInstance.setPosition({ lineNumber, column: 1 })
+    editorInstance.setPosition({ lineNumber, column: column || 1 })
     editorInstance.focus()
   }
 }

--- a/src/components/EditorPanel.vue
+++ b/src/components/EditorPanel.vue
@@ -1,11 +1,14 @@
 <template>
   <n-card title="Editor" size="small" class="panel editor" style="grid-row: 1; grid-column: 1;">
     <VueMonacoEditor
+      ref="editorRef"
       language="wgsl"
       theme="vs-dark"
       :value="localCode"
       @change="onCodeChange"
+      @mount="onEditorMount"
       style="height: 100%; width: 100%;"
+      :options="editorOptions"
     />
     <template #footer>
       <n-button @click="runShader" block>Run Shader</n-button>
@@ -16,15 +19,28 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
+import * as monaco from 'monaco-editor'
 
 const props = defineProps<{
   code: string
   runShader: () => void
 }>()
 
-const emit = defineEmits(['update:code'])
+const emit = defineEmits(['update:code', 'go-to-line'])
 
 const localCode = ref(props.code)
+const editorRef = ref()
+let editorInstance: monaco.editor.IStandaloneCodeEditor | null = null
+
+// Editor options
+const editorOptions = {
+  automaticLayout: true,
+  fontSize: 14,
+  lineNumbers: 'on' as const,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  wordWrap: 'on' as const,
+}
 
 // Update localCode when parent changes
 watch(() => props.code, (newVal) => {
@@ -33,11 +49,34 @@ watch(() => props.code, (newVal) => {
   }
 })
 
+// Monaco doesn't have native syntax validation for WGSL
+// so rely on the console panel for error display
+// instead of editor markers (i.e. gutter markers, squiggly lines)
+
 // Emit updates when localCode changes
 function onCodeChange(val: string) {
   localCode.value = val
   emit('update:code', val)
 }
+
+// Handle editor mount
+function onEditorMount(editor: monaco.editor.IStandaloneCodeEditor) {
+  editorInstance = editor
+}
+
+// Method to programmatically go to a specific line
+function goToLine(lineNumber: number) {
+  if (editorInstance) {
+    editorInstance.revealLineInCenter(lineNumber)
+    editorInstance.setPosition({ lineNumber, column: 1 })
+    editorInstance.focus()
+  }
+}
+
+// Expose methods for parent components
+defineExpose({
+  goToLine
+})
 
 </script>
 

--- a/src/shaders/error-shaders.md
+++ b/src/shaders/error-shaders.md
@@ -1,0 +1,71 @@
+1. Start with this working shader (should compile successfully):
+
+```ts
+@fragment
+fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = coord.xy / iResolution.xy;
+    let color = vec3<f32>(uv.x, uv.y, 0.5);
+    return vec4<f32>(color, 1.0);
+}
+```
+
+2. Test syntax error (missing parenthesis):
+```ts
+@fragment
+fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = coord.xy / iResolution.xy;
+    let color = vec3<f32>(uv.x, uv.y, 0.5;  // Missing closing parenthesis
+    return vec4<f32>(color, 1.0);
+}
+```
+
+3. Test type error (vec4 assigned to vec3):
+```ts
+@fragment
+fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = coord.xy / iResolution.xy;
+    let color: vec3<f32> = vec4<f32>(uv.x, uv.y, 0.5, 1.0);  // Type mismatch
+    return vec4<f32>(color, 1.0);
+}
+```
+
+4. Test undefined variable:
+```ts
+@fragment
+fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = coord.xy / iResolution.xy;
+    let color = vec3<f32>(uv.x, uv.y, undefinedVariable);  // Undefined variable
+    return vec4<f32>(color, 1.0);
+}
+```
+
+5. Test multiple errors:
+```ts
+@fragment
+fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = coord.xy / iResolution.xy;
+    let color = vec3<f32>(uv.x, uv.y, 0.5;  // Error 1: Missing parenthesis
+    let wrongType: f32 = vec3<f32>(1.0, 0.0, 0.0);  // Error 2: Type mismatch
+    return vec4<f32>(undefinedVar, 1.0);  // Error 3: Undefined variable
+}
+```
+
+6. Beautiful working example (animated rings):
+```ts
+@fragment
+fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = (coord.xy - 0.5 * iResolution.xy) / iResolution.y;
+    let time = iTime * 2.0;
+
+    let angle = atan2(uv.y, uv.x) + time;
+    let radius = length(uv);
+    let rings = sin(radius * 20.0 - time * 5.0) * 0.5 + 0.5;
+
+    let r = sin(angle * 3.0 + time) * 0.5 + 0.5;
+    let g = sin(angle * 3.0 + time + 2.094) * 0.5 + 0.5;
+    let b = sin(angle * 3.0 + time + 4.188) * 0.5 + 0.5;
+
+    let color = vec3<f32>(r, g, b) * rings;
+    return vec4<f32>(color, 1.0);
+}
+```

--- a/src/webgpu/parser.ts
+++ b/src/webgpu/parser.ts
@@ -4,7 +4,6 @@ export interface ParsedError {
   message: string;
   line: number;
   column?: number;
-  severity: 'error';
 }
 
 // Get the number of lines in the injected header for line offset calculations
@@ -188,7 +187,6 @@ export function parseWebGPUErrors(errorMessage: string, headerLineOffset: number
         errors.push({
           line: adjustedLine,
           column,
-          severity: 'error',
           message: cleanErrorMessage(message)
         });
 
@@ -217,7 +215,6 @@ export function parseWebGPUErrors(errorMessage: string, headerLineOffset: number
 
         errors.push({
           line: adjustedLine,
-          severity: 'error',
           message: errorMessage.trim()
         });
         break; // Only add one generic error
@@ -229,7 +226,6 @@ export function parseWebGPUErrors(errorMessage: string, headerLineOffset: number
   if (errors.length === 0 && errorMessage.trim()) {
     errors.push({
       line: 1,
-      severity: 'error',
       message: errorMessage.trim()
     });
   }

--- a/src/webgpu/parser.ts
+++ b/src/webgpu/parser.ts
@@ -1,5 +1,22 @@
 import { WgslReflect } from 'wgsl_reflect';
 
+export interface ParsedError {
+  message: string;
+  line: number;
+  column?: number;
+  severity: 'error' | 'warning' | 'info';
+}
+
+// Get the number of lines in the injected header for line offset calculations
+export function getHeaderLineOffset(): number {
+  // Empirically determined: WebGPU error line numbers need to be adjusted by 13
+  // This accounts for:
+  // 1. injectedHeader template literal structure (leading newline + 11 declarations + trailing newline = 13 lines)
+  // 2. Additional '\n' added in renderer.ts when concatenating header + user code
+  // 3. Possible other whitespace/formatting differences in the compilation process
+  return 13;
+}
+
 export function parseWGSL(wgslCode: string) {
   try {
     const reflect = new WgslReflect(wgslCode);
@@ -34,4 +51,132 @@ export function parseWGSL(wgslCode: string) {
       error: message,
     };
   }
+}
+
+// Parse WebGPU compilation error messages into structured error objects
+export function parseWebGPUErrors(errorMessage: string, headerLineOffset: number = 0): ParsedError[] {
+  const errors: ParsedError[] = [];
+
+  if (!errorMessage) return errors;
+
+  // Skip success messages and informational messages - don't treat them as errors
+  const nonErrorPatterns = [
+    /compiled\s+and\s+executed\s+successfully/i,
+    /successfully/i,
+    /shader\s+compiled/i,
+    /compilation\s+successful/i,
+    /no\s+errors/i,
+    /detected\s+shader\s+type/i,
+    /initializing\s+webgpu/i,
+    /creating\s+/i,
+    /loaded\s+/i,
+    /texture\s+provided/i,
+    /^shader\s+type:/i,
+    /^webgpu\s+/i
+  ];
+
+  for (const pattern of nonErrorPatterns) {
+    if (pattern.test(errorMessage)) {
+      return errors; // Return empty array for non-error messages
+    }
+  }
+
+  // Common WebGPU error patterns
+  const patterns = [
+    // Pattern for errors like: "shader compilation failed at line 15, column 5: error message"
+    /(?:shader\s+)?(?:compilation\s+)?(?:failed\s+)?(?:at\s+)?line\s*[:\s]\s*(\d+)(?:,?\s*column\s*[:\s]\s*(\d+))?\s*[:\s]\s*(.+)/gi,
+
+    // Pattern for errors like: "15:5 - error: message"
+    /(\d+):(\d+)\s*-\s*(error|warning|info)\s*:\s*(.+)/gi,
+
+    // Pattern for errors like: "Line 15: error message" (but not success messages)
+    /line\s+(\d+)\s*:\s*(?!.*success)(.+)/gi,
+
+    // Pattern for errors like: "15: error message"
+    /^(\d+)\s*:\s*(.+)/gmi,
+
+    // Pattern for errors with line references: "at line 15" (but not success messages)
+    /at\s+line\s+(\d+)(?:\s*:\s*(?!.*success)(.+))?/gi,
+  ];
+
+  for (const pattern of patterns) {
+    let match;
+    pattern.lastIndex = 0; // Reset regex state
+
+    while ((match = pattern.exec(errorMessage)) !== null) {
+      const line = parseInt(match[1], 10);
+      let column: number | undefined;
+      let severity: 'error' | 'warning' | 'info' = 'error';
+      let message: string;
+
+      // Handle different capture group patterns
+      if (match.length === 4 && match[2] && /^\d+$/.test(match[2])) {
+        // Pattern with line and column
+        column = parseInt(match[2], 10);
+        message = match[3].trim();
+      } else if (match.length === 5) {
+        // Pattern with line, column, severity, and message
+        column = parseInt(match[2], 10);
+        severity = match[3].toLowerCase() as 'error' | 'warning' | 'info';
+        message = match[4].trim();
+      } else {
+        // Pattern with just line and message
+        message = (match[2] || match[3] || '').trim();
+      }
+
+      if (line > 0 && message) {
+        // Adjust line number to account for injected header
+        const adjustedLine = Math.max(1, line - headerLineOffset);
+
+        errors.push({
+          line: adjustedLine,
+          column,
+          severity,
+          message: cleanErrorMessage(message)
+        });
+      }
+    }
+  }
+
+  // If no structured errors found, try to extract any line numbers
+  if (errors.length === 0) {
+    const linePattern = /line\s*[:\s]\s*(\d+)/gi;
+    let match;
+
+    while ((match = linePattern.exec(errorMessage)) !== null) {
+      const line = parseInt(match[1], 10);
+      if (line > 0) {
+        // Adjust line number to account for injected header
+        const adjustedLine = Math.max(1, line - headerLineOffset);
+
+        errors.push({
+          line: adjustedLine,
+          severity: 'error',
+          message: errorMessage.trim()
+        });
+        break; // Only add one generic error
+      }
+    }
+  }
+
+  // If still no errors but we have an error message, add a generic error at line 1
+  if (errors.length === 0 && errorMessage.trim()) {
+    errors.push({
+      line: 1,
+      severity: 'error',
+      message: errorMessage.trim()
+    });
+  }
+
+  return errors;
+}
+
+// Clean up error messages by removing redundant information
+function cleanErrorMessage(message: string): string {
+  return message
+    // Remove line/column references that are now handled separately
+    .replace(/(?:at\s+)?line\s+\d+(?:,?\s*column\s+\d+)?[:\s]*/gi, '')
+    .replace(/^\d+:\d+\s*-\s*(?:error|warning|info)\s*:\s*/gi, '')
+    .replace(/^error\s*:\s*/gi, '')
+    .trim();
 }

--- a/src/webgpu/parser.ts
+++ b/src/webgpu/parser.ts
@@ -179,9 +179,6 @@ export function parseWebGPUErrors(errorMessage: string, headerLineOffset: number
 
         if (isCompilationError) {
           adjustedLine = Math.max(1, line - headerLineOffset);
-          console.log(`Compilation error - Line adjustment: original=${line}, offset=${headerLineOffset}, adjusted=${adjustedLine}`);
-        } else {
-          console.log(`Parser error - Using original line: ${line}`);
         }
 
         errors.push({


### PR DESCRIPTION
This PR improves the console experience for WGSL shader compilation errors by introducing structured parsing, clickable navigation, and visual refinements.

**Changes:**
- **Structured WGSL Error Parsing**
  - Extracts `line` and `column` numbers from compiler output.
  - Generates clickable links that jump directly to the exact location in the Monaco editor.
- **Visual Enhancements**
  - Applied monospace font to console messages
  - Restyled WGSL error messages in the console

These updates make debugging WGSL shaders more intuitive by turning raw compiler text into actionable, styled error messages with direct navigation support.

---

### Before and After Screenshots

Previously, messages on the console looked like this:

<img width="748" height="212" alt="Screenshot 2025-08-10 at 9 16 40 PM" src="https://github.com/user-attachments/assets/9f50efbd-715c-460c-a44c-93f0aadc7241" />

<img width="748" height="212" alt="Screenshot 2025-08-10 at 9 15 57 PM" src="https://github.com/user-attachments/assets/b972969e-8cb0-4ccf-accc-3c6283b77b6b" />

<img width="748" height="212" alt="Screenshot 2025-08-10 at 9 16 11 PM" src="https://github.com/user-attachments/assets/2739321b-0868-491b-8607-fb0d6cedc250" />

After the changes, this is what it looks like:

<img width="748" height="212" alt="Screenshot 2025-08-10 at 9 15 27 PM" src="https://github.com/user-attachments/assets/372a955b-ecf7-4b91-9035-4feb09ae8675" />

<img width="748" height="212" alt="Screenshot 2025-08-10 at 9 15 44 PM" src="https://github.com/user-attachments/assets/a9b611d3-740c-49df-b300-0c7bbf310474" />

<img width="748" height="212" alt="Screenshot 2025-08-10 at 9 16 22 PM" src="https://github.com/user-attachments/assets/0a5b988b-0999-49a9-9124-127a40b4aa2d" />

---

Closes #56 and #63 