### PR TITLE
Set bot git identity for deploy workflow + remove GH_TOKEN.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,13 @@ jobs:
       - name: Build
         run: npm run build
 
+      # retrieved from https://github.com/orgs/community/discussions/26560
+      - name: Git identity (use bot)
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
       - name: Deploy (gh-pages)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run deploy


### PR DESCRIPTION
 This PR updates the GitHub Pages deploy workflow to explicitly set the `github-actions[bot]` identity before running the deploy step. This ensures `gh-pages` can commit and push to the `gh-pages` branch without author identity errors.

**Changes**:
- Added a step to configure Git with:
  ```
  user.name = github-actions[bot]
  user.email = github-actions[bot]@users.noreply.github.com
  ```
- Removed redundant `GH_TOKEN` environment variable -- `GITHUB_TOKEN` is sufficient for authentication.

Closes #58 