### PR TITLE
Fix auth error for CI/CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main] # runs after a PR is merged to main
+    branches: [main, ci/github-actions] # runs after a PR is merged to main
 
 permissions:
   contents: write # needed to push to gh-pages
@@ -40,5 +40,6 @@ jobs:
 
       - name: Deploy (gh-pages)
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main, ci/github-actions] # runs after a PR is merged to main
+    branches: [main] # runs after a PR is merged to main
 
 permissions:
   contents: write # needed to push to gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 
       - name: Deploy (gh-pages)
         env:


### PR DESCRIPTION
Stabilises the GitHub Pages deployment by fixing authentication for the `gh-pages` push

**Changes:**
- **Fix deploy auth:** Set a tokenized origin in the workflow  
  `git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/<repo>.git`
- **Compat tokens:** Restored `GH_TOKEN` alongside `GITHUB_TOKEN` for `gh-pages` compatibility.
- **Scope triggers:** Removed the feature branch from the workflow; deploy now runs **only** on pushes to `main`.

Resolves the “could not read Username for 'https://github.com'” error during deploy.

Closes #58 