### PR TITLE
CI/CD optimisations - path filters, manual runs, and smarter concurrency

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -4,10 +4,24 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'vite.config.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig*.json'
+  workflow_dispatch: {}     # manual run when needed
+
+# auto-cancels older runs if new commits are pushed to the same PR
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -3,13 +3,37 @@ name: Run Unit Tests
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'            # app code
+      - 'public/**'         # static assets
+      - 'index.html'        # Vite entry
+      - 'vite.config.ts'    # build config
+      - 'package.json'      # deps/scripts can change output
+      - 'package-lock.json' # lockfile updates can change output
+      - 'tsconfig*.json'    # TS config may affect build
+      - 'tests/**'          # tests change
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: [main]
+    paths:
+      - 'src/**'            # app code
+      - 'public/**'         # static assets
+      - 'index.html'        # Vite entry
+      - 'vite.config.ts'    # build config
+      - 'package.json'      # deps/scripts can change output
+      - 'package-lock.json' # lockfile updates can change output
+      - 'tsconfig*.json'    # TS config may affect build
+      - 'tests/**'          # tests change
+  workflow_dispatch: {}     # manual run when needed
+
+# auto-cancels older runs if new commits are pushed to the same PR
+concurrency:
+  group: tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
+  cancel-in-progress: true
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,15 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main] # runs after a PR is merged to main
+    paths:
+      - 'src/**'            # app code
+      - 'public/**'         # static assets
+      - 'index.html'        # Vite entry
+      - 'vite.config.ts'    # build config
+      - 'package.json'      # deps/scripts can change output
+      - 'package-lock.json' # lockfile updates can change output
+      - 'tsconfig*.json'    # TS config may affect build
+  workflow_dispatch: {}     # manual redeploy when needed
 
 permissions:
   contents: write # needed to push to gh-pages


### PR DESCRIPTION
Tightens when workflows run, adds a manual trigger, and cancels stale jobs to make CI/CD faster and less noisy.

**Changes:**
- **Scoped triggers with path filters**
  - Only run when build/test–affecting files change:
    - `src/**`, `public/**`, `index.html`, `vite.config.ts`, `package.json`, `package-lock.json`, `tsconfig*.json`
    - Plus `tests/**` for the unit test workflow.
- **Manual run support**
  - Added `workflow_dispatch` to all three workflows (manual build/test/deploy without a commit).
- **Cancel stale runs**
  - Added `concurrency` to PR workflows:
    - Build: `pr-build-${{ github.event.pull_request.number || github.run_id }}`
    - Tests: `tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}`
  - New pushes to the same PR cancel in-progress runs.
- **Safer job guards**
  - Build & Tests jobs now run on **push**/manual runs and on **non-draft PRs**:
    - `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`

**Impact:**
- Fewer unnecessary CI runs (docs/CI-only changes won’t trigger build/test/deploy).
- Faster feedback by cancelling outdated jobs.
- Ability to manually re-run build/tests/deploy on demand.
