### PR TITLE
Fix Console overflow and add smooth scrolling

### DIFF
--- a/src/components/ConsolePanel.vue
+++ b/src/components/ConsolePanel.vue
@@ -1,7 +1,8 @@
 <template>
   <!-- Console (bottom-right) -->
-  <n-card title="Console" size="small" class="panel panel-console" style="grid-row: 2; grid-column: 2;">
-    <div class="console-content">
+  <n-card title="Console" size="small" class="panel-console" style="grid-row: 2; grid-column: 2;">
+    <n-scrollbar style="max-height: 100%;">
+      <div class="console-content">
       <!-- Structured error display -->
       <div v-if="structuredErrors.length > 0" class="structured-errors">
         <div v-for="(error, index) in structuredErrors" :key="index"
@@ -41,6 +42,7 @@
         </template>
       </div>
     </div>
+    </n-scrollbar>
   </n-card>
 </template>
 
@@ -141,33 +143,47 @@ const tokens = computed(() => {
 </script>
 
 <style scoped>
+/* Force console card to be a flex container with proper height */
 .panel-console {
-  display: flex;
-  flex-direction: column;
+  height: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
   min-height: 0;
+  min-width: 0;
 }
 
-.panel-console .n-card__content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
+/* Override Naive UI card styles */
+.panel-console :deep(.n-card) {
+  height: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
 }
 
-.panel-console .console-content {
-  flex: 1;
-  overflow-y: auto;     /* scroll when it overflows */
+.panel-console :deep(.n-card__content) {
+  display: flex !important;
+  flex-direction: column !important;
+  flex: 1 !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+  padding: 12px !important;
+}
+
+/* Console content with proper scrolling */
+.console-content {
+  flex: 1 !important;
   padding-bottom: 16px;
+  max-width: 100%;      /* ensure content doesn't exceed panel width */
 }
-
 .console-pre {
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
                "Liberation Mono", "Courier New", monospace;
   white-space: pre-wrap;        /* keep newlines/indentation, allow wrapping */
   word-break: break-word;       /* avoid horizontal scroll on long tokens */
+  overflow-wrap: break-word;    /* additional word breaking for long strings */
   font-variant-ligatures: none; /* no confusing 'fi'/'fl' ligatures etc. */
   tab-size: 2;
+  max-width: 100%;              /* ensure it doesn't exceed container width */
 }
 
 .line-link {
@@ -225,6 +241,9 @@ const tokens = computed(() => {
   font-size: 12px;
   color: #ccc;
   line-height: 1.4;
+  word-break: break-word;       /* break long words */
+  overflow-wrap: break-word;    /* additional word breaking */
+  max-width: 100%;              /* ensure it doesn't exceed container width */
 }
 
 /* Compilation error styling for raw console output */
@@ -236,5 +255,8 @@ const tokens = computed(() => {
   border-radius: 4px;
   display: block;
   line-height: 1.4;
+  word-break: break-word;       /* break long words */
+  overflow-wrap: break-word;    /* additional word breaking */
+  max-width: 100%;              /* ensure it doesn't exceed container width */
 }
 </style>


### PR DESCRIPTION
This PR resolves an overflow issue in the Console panel and introduces a reliable scroll experience using `n-scrollbar`, ensuring long error output doesn’t spill outside the card and remains readable.

**Changes:**
- **UI structure**
  - Replace extra `panel` class and wrap console content with `<n-scrollbar>` (`max-height: 100%`) to manage vertical overflow.
  - Keep the card layout stable with a single `panel-console` class.
- **Styling & layout**
  - Force the Console card to be a full-height flex container (`height: 100%`, `display: flex`) and normalize Naive UI internals via `:deep()` overrides.
  - Move overflow handling from `.console-content` to `n-scrollbar`; simplify `.console-content` to flex child with padding.
  - Add `word-break` / `overflow-wrap` and `max-width: 100%` to prevent horizontal scrolling on long tokens/lines.
- **Code cleanup**
  - Minor template/class tweaks to remove redundancy and align styles with actual structure.

**Impact:**
- Long compiler/error logs are contained within the panel and scroll smoothly.
- No more layout shifts or content spilling into adjacent grid areas.
- Better readability of long lines without horizontal scroll.

**Verification:**
- Generate long WGSL error output and confirm:
  - The Console stays within its grid cell.
  - Vertical scroll appears inside the card (no page scroll hijack).
  - Long lines wrap and do not cause horizontal overflow.

tested with this wgsl code that should give a longer error:

```wgsl
// binding(11): uniform (x=gain, y=bias)
struct Extra { params: vec4<f32> }
@group(0) @binding(11) var<uniform> extra : Extra;

// binding(12): read-only storage buffer (16 vec4s)
struct Lut { data: array<vec4<f32>, 16> }
@group(0) @binding(12) var<storage, read> lut : Lut;

// binding(13): extra texture (separate from iChannel0..3)
@group(0) @binding(13) var auxTex : texture_2d<f32>;

// assumes your injected sampler at @binding(1)
@group(0) @binding(1) var iSampler : sampler;

@fragment
fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
  let uv = pos.xy / iResolution.xy;
  let t  = textureSampleLevel(auxTex, iSampler, uv, 0.0); // vec4<f32>

  let idx : u32 = u32(floor(fract(uv.x + uv.y + extra.params.y) * 16.0));
  let c   : vec4<f32> = lut.data[idx];

  let mixed = (1.0 - extra.params.x) * t + extra.params.x * c;
  return vec4<f32>(mixed.rgb, 1.0);
}
```

Closes #71 