### PR TITLE
Update wgsl_reflect to latest with typo fix.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "monaco-editor": "^0.52.2",
         "obj-file-parser": "^0.6.2",
         "vue": "^3.5.13",
-        "wgsl_reflect": "^1.2.1"
+        "wgsl_reflect": "github:brendan-duncan/wgsl_reflect"
       },
       "devDependencies": {
         "@testing-library/vue": "^8.1.0",
@@ -4861,9 +4861,8 @@
       }
     },
     "node_modules/wgsl_reflect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.1.tgz",
-      "integrity": "sha512-PY6MdLqLW1NFj/V6f5/9/Nb4ultwlAF7lCLyjKOAkdnlf7LlrGXNFXzHHEV7Okg1zy4C4TpBIcc/G3PXW4py8g==",
+      "version": "1.2.3",
+      "resolved": "git+ssh://git@github.com/brendan-duncan/wgsl_reflect.git#67e1e0b71af56e4cd684a755e0e8ae4ab0345773",
       "license": "MIT"
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "monaco-editor": "^0.52.2",
     "obj-file-parser": "^0.6.2",
     "vue": "^3.5.13",
-    "wgsl_reflect": "^1.2.1"
+    "wgsl_reflect": "github:brendan-duncan/wgsl_reflect"
   },
   "devDependencies": {
     "@testing-library/vue": "^8.1.0",


### PR DESCRIPTION
This PR updates the `wgsl_reflect` dependency to the latest commit from [brendan-duncan/wgsl_reflect](https://github.com/brendan-duncan/wgsl_reflect), which includes a fix for a typo (`agument` → `argument`) that was previously visible in our console output.  

### Background  
The typo fix was contributed upstream via:  
- [PR #78](https://github.com/brendan-duncan/wgsl_reflect/pull/78) – Source code typo fix.  
- [PR #79](https://github.com/brendan-duncan/wgsl_reflect/pull/79) – Rebuilt distribution files to include the fix.  

Once merged upstream, the dependency in this project was updated to point to the latest commit containing these changes. This ensures that the fix is now integrated into our local environment without requiring any manual patching.

Screenshot of the fixed typo:
<img width="1512" height="982" alt="Screenshot 2025-08-12 at 5 09 43 PM" src="https://github.com/user-attachments/assets/d4d524b3-3484-4e14-874d-9883e61bd90a" />

> **Note:** [PR #80](https://github.com/brendan-duncan/wgsl_reflect/pull/80) is currently open upstream to add automated continuous deployment for rebuilt distribution files. While related to upstream workflow improvements, it is not directly relevant to this change.  

Closes #76 
