### PR TITLE
Add clickable title header linking to documentation page.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -53,6 +53,13 @@ function openDocs() {
   window.open('https://anukritiw.github.io/splitshade-docs/', '_blank')
 }
 
+function handleTitleHover(event: MouseEvent, opacity: string) {
+  const target = event.target as HTMLElement
+  if (target) {
+    target.style.opacity = opacity
+  }
+}
+
 function handleRunShader() {
   if (!previewRef.value?.canvasRef) return
   consoleOutput.value = ''
@@ -89,8 +96,8 @@ function handleGoToLine(line: number, column?: number) {
           <h2
             style="margin: 0; color: white; cursor: pointer; user-select: none; transition: opacity 0.2s ease;"
             @click="openDocs"
-            @mouseenter="$event.target.style.opacity = '0.8'"
-            @mouseleave="$event.target.style.opacity = '1'"
+            @mouseenter="handleTitleHover($event, '0.8')"
+            @mouseleave="handleTitleHover($event, '1')"
             title="Click to open documentation"
           >
             SplitShade: WebGPU Playground

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,10 @@ const consoleOutput = ref("")
 
 const { runShader } = useShaderRunner()
 
+function openDocs() {
+  window.open('https://anukritiw.github.io/splitshade-docs/', '_blank')
+}
+
 function handleRunShader() {
   if (!previewRef.value?.canvasRef) return
   consoleOutput.value = ''
@@ -82,15 +86,20 @@ function handleGoToLine(line: number, column?: number) {
     <div class="root-grid">
       <n-layout-header bordered style="padding: 12px;">
         <div class="header-content">
-          <h2 style="margin: 0; color: white;">SplitShade: WebGPU Playground</h2>
+          <h2
+            style="margin: 0; color: white; cursor: pointer; user-select: none; transition: opacity 0.2s ease;"
+            @click="openDocs"
+            @mouseenter="$event.target.style.opacity = '0.8'"
+            @mouseleave="$event.target.style.opacity = '1'"
+            title="Click to open documentation"
+          >
+            SplitShade: WebGPU Playground
+          </h2>
           <div class="header-links">
             <n-button
               class="docs-button"
               text
-              tag="a"
-              href="https://anukritiw.github.io/splitshade-docs"
-              target="_blank"
-              rel="noopener"
+              @click="openDocs"
               title="Read the docs"
             >
               <span>Docs ↗</span>


### PR DESCRIPTION
This PR updates the title header on the page so that clicking it opens the project’s documentation page.  

Previously, clicking the title had no action, which could be a missed opportunity to guide users to helpful resources. Now the title links directly to the docs page which opens in a new tab.

**Changes:**
- Added click handler to the title header.
- Configured the handler to navigate to the project’s documentation page in a new browser tab.

**Impact:**
- Improves discoverability of documentation.
- Provides a more interactive and purposeful header.
- Reduces friction for new users looking for usage guides or reference material.

Closes #72 