### PR TITLE
Add default shader example with auto-run on page load.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { darkTheme } from 'naive-ui'
-import { ref } from 'vue'
-const code = ref(`// Write your WGSL code here`)
+import { ref, onMounted, nextTick } from 'vue'
+const code = ref(`@fragment
+fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = coord.xy / iResolution.xy;
+    let color = vec3<f32>(uv.x, uv.y, 0.5);
+    return vec4<f32>(color, 1.0);
+}`)
 
 import { loader } from '@guolao/vue-monaco-editor'
 import { LogoGithub } from '@vicons/ionicons5'
@@ -85,6 +90,14 @@ function handleGoToLine(line: number, column?: number) {
     editorRef.value.goToLine(line, column)
   }
 }
+
+// auto-run the initial shader when the app mounts
+onMounted(() => {
+  // Wait for the next DOM update cycle to ensure all child components are rendered
+  nextTick(() => {
+    handleRunShader()
+  })
+})
 </script>
 
 <template>
@@ -158,8 +171,8 @@ function handleGoToLine(line: number, column?: number) {
           @selectPresetMesh="selectPresetMesh"
           @downloadMesh="downloadMesh"
           @handleMeshUpload="handleMeshUpload"
-          @update:showTextureModal="val => showTextureModal = val"
-          @update:showMeshModal="val => showMeshModal = val"
+          @update:showTextureModal="(val: boolean) => showTextureModal = val"
+          @update:showMeshModal="(val: boolean) => showMeshModal = val"
         />
 
         <!-- Console (bottom-right) -->


### PR DESCRIPTION
This PR introduces an initial shader in the application.  

### Changes  
- Updated the default shader code with a simple WGSL fragment shader.
- Added an `onMounted` hook with `nextTick` to ensure the shader is automatically executed once the app finishes rendering.
- Improved event binding in template by explicitly typing `val` as `boolean` for modal updates (`showTextureModal` and `showMeshModal`).

### Motivation  
Like Shadertoy, there is a starter code in the editor as a starting point

<img width="1512" height="982" alt="Screenshot 2025-08-12 at 8 10 52 PM" src="https://github.com/user-attachments/assets/33c6e832-c060-4a6a-966c-51542104c1c8" />

Closes #78 