### PR TITLE
Add GPLv3 license headers and README notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ All AI-assisted outputs were reviewed, adapted, and verified before inclusion.
 
 ---
 
+## License
+
+Copyright © 2025 Anu Kriti Wadhwa.
+
+This project is licensed under the GNU GPL v3. See the LICENSE file for details.
+
+---
+
 <div align="center">
   Made with ❤️ by <a href="https://github.com/AnuKritiW">AnuKritiW</a>
 </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,21 @@
+<!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
 <script setup lang="ts">
 /**
  * SplitShade WebGPU Playground - Main Application Component

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * WebGPU context management and device initialization.
  *

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * Application Entry Point
  *

--- a/src/pipeline/pipeline.ts
+++ b/src/pipeline/pipeline.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * WebGPU Render Pipeline Factory
  *

--- a/src/pipeline/uniforms.ts
+++ b/src/pipeline/uniforms.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * WebGPU Uniform Buffer Management
  *

--- a/src/resources/mesh/objParser.ts
+++ b/src/resources/mesh/objParser.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import ObjFileParser from 'obj-file-parser'
 
 /**

--- a/src/resources/textures.ts
+++ b/src/resources/textures.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * WebGPU Texture Loading and Management
  *

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * WebGPU Shader Renderer
  *

--- a/src/shader/shaderUtils.ts
+++ b/src/shader/shaderUtils.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 /**
  * WebGPU Shader Management and Compilation
  *

--- a/src/shader/wgslReflect.ts
+++ b/src/shader/wgslReflect.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { WgslReflect } from 'wgsl_reflect';
 
 /**

--- a/src/ui/components/WebGPUWarning.vue
+++ b/src/ui/components/WebGPUWarning.vue
@@ -1,4 +1,22 @@
 <!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
 /**
  * WebGPUWarning Component
  *

--- a/src/ui/components/modals/MeshModal.vue
+++ b/src/ui/components/modals/MeshModal.vue
@@ -1,4 +1,22 @@
 <!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
 /**
  * MeshModal Component
  *

--- a/src/ui/components/modals/TextureModal.vue
+++ b/src/ui/components/modals/TextureModal.vue
@@ -1,4 +1,22 @@
 <!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
 /**
  * TextureModal Component
  *

--- a/src/ui/components/panels/ConsolePanel.vue
+++ b/src/ui/components/panels/ConsolePanel.vue
@@ -1,3 +1,21 @@
+<!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
 <template>
   <!-- Console (bottom-right) -->
   <n-card title="Console" size="small" class="panel-console" style="grid-row: 2; grid-column: 2;">

--- a/src/ui/components/panels/EditorPanel.vue
+++ b/src/ui/components/panels/EditorPanel.vue
@@ -1,4 +1,22 @@
 <!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
 /**
  * EditorPanel Component
  *

--- a/src/ui/components/panels/PreviewPanel.vue
+++ b/src/ui/components/panels/PreviewPanel.vue
@@ -1,4 +1,22 @@
 <!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
 /**
  * PreviewPanel Component
  *

--- a/src/ui/components/panels/ResourcesPanel.vue
+++ b/src/ui/components/panels/ResourcesPanel.vue
@@ -1,3 +1,21 @@
+<!--
+  SPDX-License-Identifier: GPL-3.0-only
+
+  SplitShade: WebGPU Playground
+  Copyright (C) 2025 Anu Kriti Wadhwa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
 <script setup lang="ts">
 /**
  * ResourcesPanel Component

--- a/src/ui/composables/useMesh.ts
+++ b/src/ui/composables/useMesh.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { ref, reactive } from 'vue'
 
 import { parseObjToVertices } from '@/resources/mesh/objParser'

--- a/src/ui/composables/useShaderRunner.ts
+++ b/src/ui/composables/useShaderRunner.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { initWebGPU } from '@/runtime/renderer'
 
 type ChannelMap = {

--- a/src/ui/composables/useTextures.ts
+++ b/src/ui/composables/useTextures.ts
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * SplitShade: WebGPU Playground
+ * Copyright (C) 2025 Anu Kriti Wadhwa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { ref, computed } from 'vue'
 
 import { DEFAULT_TEXTURES } from '@/resources/textures'


### PR DESCRIPTION
This PR adds explicit licensing and attribution information across the project.

### Changes
- Added GPLv3 license headers to source files
- Added a license section to the `README`

This helps clarify usage, attribution, and redistribution terms for contributors and downstream users.
